### PR TITLE
Fix configuration and style issues

### DIFF
--- a/.ebextensions/python.config
+++ b/.ebextensions/python.config
@@ -1,7 +1,7 @@
 {
   "option_settings": {
     "aws:elasticbeanstalk:container:python": {
-      "WSGIPath": "application.py"
+      "WSGIPath": "src/application.py"
     },
     "aws:elasticbeanstalk:application:environment": {
       "FLASK_ENV": "production"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
+Werkzeug<3.0
 gunicorn==20.1.0

--- a/src/application.py
+++ b/src/application.py
@@ -1,11 +1,19 @@
 from flask import Flask
+import os
+
 
 application = Flask(__name__)
 
+
 @application.route('/')
 def hello():
-    return '<h1>مرحباً بك في منصة الواسطة!</h1><p>تم تشغيل التطبيق بنجاح على AWS Elastic Beanstalk.</p>'
+    return (
+        '<h1>مرحباً بك في منصة الواسطة!</h1>'
+        '<p>تم تشغيل التطبيق بنجاح على AWS Elastic Beanstalk.</p>'
+    )
+
 
 # هذا هو النقطة الرئيسية للتطبيق
 if __name__ == '__main__':
-    application.run(host='0.0.0.0', port=5000)
+    port = int(os.getenv('PORT', 5000))
+    application.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- fix path to app in Elastic Beanstalk config
- pin Werkzeug version for compatibility
- fix Flask app style
- add support for configurable PORT env var

## Testing
- `flake8`
- `python -m py_compile src/application.py`
- `gunicorn src.application:application --bind 0.0.0.0:8000`

------
https://chatgpt.com/codex/tasks/task_e_6845e280d2e08330aab84ff8f3e5e326